### PR TITLE
fix: deixando a cor do btn passagem de turno no padrao

### DIFF
--- a/templates/Admin/PassagemTurno/index.php
+++ b/templates/Admin/PassagemTurno/index.php
@@ -44,7 +44,7 @@
                         <td><?= h($passagemTurno->etapa) ?></td>
                         <td><?= h($passagemTurno->assunto) ?></td>
                         <td>
-                            <?= $this->Html->link(__('Ver'), ['action' => 'view', $passagemTurno->id], ['class' => 'btn btn-outline-primary btn-sm btn-shadow']) ?>
+                            <?= $this->Html->link(__('Ver'), ['action' => 'view', $passagemTurno->id], ['class' => 'btn btn-outline-secondary btn-sm btn-shadow']) ?>
                             <?= $this->Html->link(__('Editar'), ['action' => 'edit', $passagemTurno->id], ['class' => 'btn btn-outline-warning btn-sm btn-shadow']) ?>
                             <?= $this->Form->postLink(__('Excluir'), ['action' => 'delete', $passagemTurno->id], ['class' => 'btn btn-outline-danger btn-sm btn-shadow', 'confirm' => __('Realmente deseja excluir o registro?')]) ?>
                         </td>


### PR DESCRIPTION
<!---

**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
